### PR TITLE
fix: enhance snow effect performance and renderer pixel ratio handling

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -31,8 +31,12 @@ export const CONFIG = {
         point: { intensity: 1.5, position: { x: 0, y: 3, z: 0 } },
         top: { intensity: 1.5, position: { x: 0, y: 5, z: 0 } }
     },
+    renderer: {
+        maxPixelRatio: 2 // Cap devicePixelRatio to avoid excessive fill rate on 3x+ HiDPI displays
+    },
     snow: {
-        winterMonths: [12, 1] // Months when snow is enabled by default (1-indexed: 12=Dec, 1=Jan)
+        winterMonths: [12, 1], // Months when snow is enabled by default (1-indexed: 12=Dec, 1=Jan)
+        flakesPerArea: 8000 // Viewport area (px²) per snowflake
     },
     resize: {
         debounceMs: 100

--- a/src/main.js
+++ b/src/main.js
@@ -261,9 +261,11 @@ function initializeApp() {
     // Keyboard toggle for PS1 style, snow effect, and debug mode
     const keydownHandler = (e) => {
         if (e.key === 'p' || e.key === 'P') {
-            CONFIG.ps1Style = !CONFIG.ps1Style;
-            localStorage.setItem('ps1Style', String(CONFIG.ps1Style));
-            showNotification(`PS1 Style: ${CONFIG.ps1Style ? 'ON' : 'OFF'} (reloading...)`, 0);
+            // Write the toggled value to localStorage but don't mutate CONFIG
+            // in memory — prevents jitter starting/stopping before the reload.
+            const newPs1Style = !CONFIG.ps1Style;
+            localStorage.setItem('ps1Style', String(newPs1Style));
+            showNotification(`PS1 Style: ${newPs1Style ? 'ON' : 'OFF'} (reloading...)`, 0);
             setTimeout(() => location.reload(), 800);
         }
         

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -25,7 +25,7 @@ export function createRenderer() {
         renderer.setPixelRatio(1); // Force 1:1 pixel ratio for PS1 look
     } else {
         renderer.setSize(window.innerWidth, window.innerHeight);
-        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio, CONFIG.renderer.maxPixelRatio));
     }
     
     renderer.outputColorSpace = THREE.SRGBColorSpace;

--- a/src/snow.js
+++ b/src/snow.js
@@ -125,7 +125,7 @@ export class SnowEffect {
             // Add flakes, distributing across layers
             const toAdd = targetTotal - currentTotal;
             for (let i = 0; i < toAdd; i++) {
-                const layer = this._pickLayer(i, toAdd);
+                const layer = this._pickLayer();
                 this.snowflakes.push(new Snowflake(canvasWidth, canvasHeight, layer));
             }
         } else if (targetTotal < currentTotal) {
@@ -141,12 +141,13 @@ export class SnowEffect {
     }
     
     /**
-     * Pick a layer for a new snowflake based on distribution ratios.
+     * Pick a layer for a new snowflake using weighted random selection
+     * based on LAYER_DISTRIBUTION ratios.
      */
-    _pickLayer(index, total) {
-        const ratio = index / total;
-        if (ratio < LAYER_DISTRIBUTION[0]) return 0;
-        if (ratio < LAYER_DISTRIBUTION[0] + LAYER_DISTRIBUTION[1]) return 1;
+    _pickLayer() {
+        const r = Math.random();
+        if (r < LAYER_DISTRIBUTION[0]) return 0;
+        if (r < LAYER_DISTRIBUTION[0] + LAYER_DISTRIBUTION[1]) return 1;
         return 2;
     }
     

--- a/src/snow.js
+++ b/src/snow.js
@@ -1,9 +1,10 @@
 /**
  * Snow effect with parallax layers
  * 
- * Performance: snowflakes are batched by fillStyle (opacity group) and drawn
- * with a single fill() per group. Flakes with radius ≤ 2px use fillRect()
- * instead of arc() since they are visually indistinguishable from squares.
+ * Performance: snowflake opacity is quantized to 0.1 increments so that flakes
+ * share fillStyle values and can be batched — one fill() call per opacity group.
+ * Flakes with radius ≤ 2px use fillRect() instead of arc() since they are
+ * visually indistinguishable from squares at that size.
  */
 import { CONFIG } from './config.js';
 import { isSnowSeason, debounce } from './utils.js';
@@ -171,8 +172,9 @@ export class SnowEffect {
     }
     
     /**
-     * Draw all snowflakes, batched by fillStyle to minimize canvas state changes.
-     * Small flakes (radius ≤ 2px) use fillRect; larger ones use a single Path2D per group.
+     * Draw all snowflakes, batched by fillStyle (quantized opacity) to minimize
+     * canvas state changes. Small flakes (radius ≤ 2px) use fillRect; larger
+     * ones use a single Path2D per group.
      */
     draw() {
         if (!this.enabled) return;
@@ -226,6 +228,7 @@ export class SnowEffect {
     }
     
     cleanup() {
+        this.resizeHandler.cancel();
         window.removeEventListener('resize', this.resizeHandler);
         if (this.canvas.parentNode) {
             this.canvas.parentNode.removeChild(this.canvas);

--- a/src/snow.js
+++ b/src/snow.js
@@ -86,7 +86,6 @@ export class SnowEffect {
         document.querySelector('main').appendChild(this.canvas);
         
         this.resize();
-        this.createSnowflakes();
         
         // Handle window resize (debounced to match renderer resize behavior)
         this.resizeHandler = debounce(() => this.resize(), CONFIG.resize.debounceMs);
@@ -149,21 +148,6 @@ export class SnowEffect {
         if (r < LAYER_DISTRIBUTION[0]) return 0;
         if (r < LAYER_DISTRIBUTION[0] + LAYER_DISTRIBUTION[1]) return 1;
         return 2;
-    }
-    
-    createSnowflakes() {
-        const numFlakes = Math.max(
-            Math.floor((this.canvas.width * this.canvas.height) / CONFIG.snow.flakesPerArea),
-            MIN_SNOWFLAKES
-        );
-        
-        // Create 3 layers with different quantities
-        for (let layer = 0; layer < 3; layer++) {
-            const count = Math.floor(numFlakes * LAYER_DISTRIBUTION[layer]);
-            for (let i = 0; i < count; i++) {
-                this.snowflakes.push(new Snowflake(this.canvas.width, this.canvas.height, layer));
-            }
-        }
     }
     
     update(delta) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,16 +19,19 @@ export function checkWebGLSupport() {
 /**
  * Creates a debounced version of a function that delays its execution
  * until after a specified wait time has elapsed since the last call.
+ * The returned function has a .cancel() method to clear any pending timeout.
  * @param {Function} func - The function to debounce
  * @param {number} wait - The number of milliseconds to wait before executing
- * @returns {Function} A debounced version of the input function
+ * @returns {Function} A debounced version of the input function with a cancel() method
  */
 export function debounce(func, wait) {
     let timeout;
-    return function(...args) {
+    const debounced = function(...args) {
         clearTimeout(timeout);
         timeout = setTimeout(() => func.apply(this, args), wait);
     };
+    debounced.cancel = () => clearTimeout(timeout);
+    return debounced;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces significant performance and configurability improvements to the snow effect and rendering system. The main changes include batching snowflake drawing to reduce canvas operations, dynamically adjusting snowflake count based on viewport area, and capping the renderer's pixel ratio for better performance on high-DPI displays.

Performance improvements to snow effect:

* Snowflake drawing is now batched by `fillStyle` (opacity group), minimizing canvas state changes and reducing draw calls. Small flakes (radius ≤ 2px) use `fillRect()` instead of `arc()` for efficiency, and large flakes are drawn with a single `Path2D` per group. (`src/snow.js`) [[1]](diffhunk://#diff-b99fde428b188df90e3770cc388b767b4ecd99a38649cb7de43d42c8a3f66c47R3-R15) [[2]](diffhunk://#diff-b99fde428b188df90e3770cc388b767b4ecd99a38649cb7de43d42c8a3f66c47R158-R202)
* The snowflake count is dynamically adjusted on window resize to match the viewport area, ensuring consistent density regardless of screen size. Flakes are distributed across layers according to defined ratios. (`src/snow.js`)

Configurability and renderer optimizations:

* Added `renderer.maxPixelRatio` to `CONFIG`, capping device pixel ratio to 2 to prevent excessive fill rate on HiDPI displays. The renderer now uses this cap when setting pixel ratio. (`src/config.js`, `src/renderer.js`) [[1]](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cR34-R39) [[2]](diffhunk://#diff-1b3a93ed16f5deb8d482f3295fc99339adf138e2bf197e65a5fe3964f5e1c93eL28-R28)
* Snowflake density is now configurable via `CONFIG.snow.flakesPerArea`, allowing easy adjustment of snow effect density. (`src/config.js`, `src/snow.js`) [[1]](diffhunk://#diff-23821ae067a9c7dfb6227774aefb39fa3951a5874ea953b9401dfc80175c026cR34-R39) [[2]](diffhunk://#diff-b99fde428b188df90e3770cc388b767b4ecd99a38649cb7de43d42c8a3f66c47L84-R145)

Code cleanup and consistency:

* Debounced window resize handling for the snow effect to match renderer behavior, improving responsiveness and preventing excessive recalculation. (`src/snow.js`)