### PR TITLE
chore: update actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       interval: "weekly"
       day: "sunday"
     cooldown:
-      default-days: 5
+      default-days: 7
     commit-message:
       prefix: chore
       include: scope

--- a/.github/workflows/deploy-static-page.yml
+++ b/.github/workflows/deploy-static-page.yml
@@ -34,20 +34,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
         with:
           lfs: true
           persist-credentials: false
       
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # Upload entire repository
           path: '.'
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
This pull request updates CI/CD configuration files to improve dependency management and enhance security by pinning GitHub Actions to specific commit SHAs. The most important changes are:

**Security and Dependency Management:**

* Updated all GitHub Actions in `.github/workflows/deploy-static-page.yml` to use specific commit SHAs instead of version tags, which helps prevent supply chain attacks by ensuring the exact action code is used.

**Configuration Adjustments:**

* Increased the `default-days` cooldown for Dependabot updates from 5 to 7 days in `.github/dependabot.yml`, spacing out automated dependency PRs.