### PR TITLE
fix: resolve maintainability issues with code flagged by SonarQube

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,12 +21,10 @@
             <div>Please enable JavaScript to view this 3D content.</div>
         </div>
     </noscript>
-    <div id="loading" role="status" aria-live="polite">
+    <output id="loading" aria-live="polite">
         <div>Loading...</div>
-        <div id="progress-bar" role="progressbar" aria-label="Loading progress" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
-            <div id="progress-fill"></div>
-        </div>
-    </div>
+        <progress id="progress-bar" aria-label="Loading progress" value="0" max="100"></progress>
+    </output>
     <div id="fps-counter" aria-hidden="true">FPS: --</div>
     </main>
     <!-- Import map integrity is part of the HTML Living Standard and enforced

--- a/src/config.js
+++ b/src/config.js
@@ -25,9 +25,9 @@ export const CONFIG = {
         position: { x: 0, y: 1, z: 2 }
     },
     lighting: {
-        ambient: 1.0,
+        ambient: 1,
         directional1: { intensity: 2.5, position: { x: 2, y: 2, z: 2 } },
-        directional2: { intensity: 2.0, position: { x: -2, y: 0, z: -2 } },
+        directional2: { intensity: 2, position: { x: -2, y: 0, z: -2 } },
         point: { intensity: 1.5, position: { x: 0, y: 3, z: 0 } },
         top: { intensity: 1.5, position: { x: 0, y: 5, z: 0 } }
     },
@@ -43,13 +43,13 @@ export const CONFIG = {
     },
     background: {
         colors: [
-            [1.0, 0.6, 0.0],  // acid orange
-            [1.0, 0.0, 1.0],  // magenta
-            [1.0, 0.0, 0.0],  // red
-            [0.5, 0.0, 0.5],  // purple
-            [0.0, 1.0, 0.0],  // green
-            [0.0, 1.0, 1.0],  // cyan
-            [0.0, 0.0, 1.0]   // blue
+            [1, 0.6, 0],  // acid orange
+            [1, 0, 1],  // magenta
+            [1, 0, 0],  // red
+            [0.5, 0, 0.5],  // purple
+            [0, 1, 0],  // green
+            [0, 1, 1],  // cyan
+            [0, 0, 1]   // blue
         ]
     }
 };

--- a/src/controls.js
+++ b/src/controls.js
@@ -113,21 +113,21 @@ export function initializeControls() {
     }
     
     // Attach event listeners
-    window.addEventListener('mousedown', onMouseDown);
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
-    window.addEventListener('touchstart', onTouchStart, { passive: false });
-    window.addEventListener('touchmove', onTouchMove, { passive: false });
-    window.addEventListener('touchend', onTouchEnd, { passive: false });
-    
+    globalThis.addEventListener('mousedown', onMouseDown);
+    globalThis.addEventListener('mousemove', onMouseMove);
+    globalThis.addEventListener('mouseup', onMouseUp);
+    globalThis.addEventListener('touchstart', onTouchStart, { passive: false });
+    globalThis.addEventListener('touchmove', onTouchMove, { passive: false });
+    globalThis.addEventListener('touchend', onTouchEnd, { passive: false });
+
     // Cleanup function
     function cleanup() {
-        window.removeEventListener('mousedown', onMouseDown);
-        window.removeEventListener('mousemove', onMouseMove);
-        window.removeEventListener('mouseup', onMouseUp);
-        window.removeEventListener('touchstart', onTouchStart);
-        window.removeEventListener('touchmove', onTouchMove);
-        window.removeEventListener('touchend', onTouchEnd);
+        globalThis.removeEventListener('mousedown', onMouseDown);
+        globalThis.removeEventListener('mousemove', onMouseMove);
+        globalThis.removeEventListener('mouseup', onMouseUp);
+        globalThis.removeEventListener('touchstart', onTouchStart);
+        globalThis.removeEventListener('touchmove', onTouchMove);
+        globalThis.removeEventListener('touchend', onTouchEnd);
     }
     
     return { mouseState, cleanup };

--- a/src/loader.js
+++ b/src/loader.js
@@ -22,16 +22,11 @@ export function loadModel(scene, onSuccess, attemptNumber = 1) {
         loadingEl.textContent = '';
         const loadingText = document.createElement('div');
         loadingText.textContent = `Loading... (Attempt ${attemptNumber}/${CONFIG.modelRetryAttempts})`;
-        const progressBar = document.createElement('div');
+        const progressBar = document.createElement('progress');
         progressBar.id = 'progress-bar';
-        progressBar.setAttribute('role', 'progressbar');
         progressBar.setAttribute('aria-label', 'Loading progress');
-        progressBar.setAttribute('aria-valuenow', '0');
-        progressBar.setAttribute('aria-valuemin', '0');
-        progressBar.setAttribute('aria-valuemax', '100');
-        const progressFill = document.createElement('div');
-        progressFill.id = 'progress-fill';
-        progressBar.appendChild(progressFill);
+        progressBar.max = 100;
+        progressBar.value = 0;
         loadingEl.appendChild(loadingText);
         loadingEl.appendChild(progressBar);
     }
@@ -104,16 +99,9 @@ export function loadModel(scene, onSuccess, attemptNumber = 1) {
         },
         function (xhr) {
             // Update progress bar
-            const progressFillEl = document.getElementById('progress-fill');
             const progressBarEl = document.getElementById('progress-bar');
-            if (xhr.lengthComputable && progressFillEl) {
-                const percentComplete = (xhr.loaded / xhr.total) * 100;
-                progressFillEl.style.width = percentComplete + '%';
-                
-                // Update ARIA value for accessibility
-                if (progressBarEl) {
-                    progressBarEl.setAttribute('aria-valuenow', Math.round(percentComplete));
-                }
+            if (xhr.lengthComputable && progressBarEl) {
+                progressBarEl.value = (xhr.loaded / xhr.total) * 100;
             }
         },
         function (error) {

--- a/src/main.js
+++ b/src/main.js
@@ -226,7 +226,7 @@ function initializeApp() {
             clearTimeout(notificationTimer);
             notificationTimer = null;
         }
-        if (notificationEl && notificationEl.parentNode) {
+        if (notificationEl?.parentNode) {
             notificationEl.remove();
         }
         notificationEl = null;
@@ -242,7 +242,7 @@ function initializeApp() {
     }
 
     // Expose cleanup function globally
-    window.cleanupThreeJS = cleanup;
+    globalThis.cleanupThreeJS = cleanup;
 
     // Attach resize event listener
     const debouncedResize = debounce(() => onWindowResize(camera, renderer), CONFIG.resize.debounceMs);
@@ -304,14 +304,12 @@ function initializeApp() {
                 cancelAnimationFrame(animationId);
                 animationId = null;
             }
-        } else {
-            if (!animationId) {
-                // Reset the FPS measurement window so the hidden duration
-                // isn't counted as part of the next 1-second sample.
-                frameCount = 0;
-                lastFpsUpdate = performance.now();
-                animationId = requestAnimationFrame(animate);
-            }
+        } else if (!animationId) {
+            // Reset the FPS measurement window so the hidden duration
+            // isn't counted as part of the next 1-second sample.
+            frameCount = 0;
+            lastFpsUpdate = performance.now();
+            animationId = requestAnimationFrame(animate);
         }
     };
     document.addEventListener('visibilitychange', visibilityChangeHandler);

--- a/src/snow.js
+++ b/src/snow.js
@@ -77,7 +77,7 @@ export class SnowEffect {
         
         // Determine snow enabled state: respect user preference, fall back to seasonal default
         const stored = localStorage.getItem('snowEnabled');
-        this.enabled = stored !== null ? stored === 'true' : isSnowSeason(CONFIG.snow.winterMonths);
+        this.enabled = stored === null ? isSnowSeason(CONFIG.snow.winterMonths) : stored === 'true';
         
         // Style canvas
         this.canvas.className = 'snow-canvas';
@@ -249,8 +249,6 @@ export class SnowEffect {
     cleanup() {
         this.resizeHandler.cancel();
         window.removeEventListener('resize', this.resizeHandler);
-        if (this.canvas.parentNode) {
-            this.canvas.parentNode.removeChild(this.canvas);
-        }
+        this.canvas.remove();
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,8 +10,9 @@ export function checkWebGLSupport() {
     try {
         const canvas = document.createElement('canvas');
         const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-        return !!(window.WebGLRenderingContext && gl);
-    } catch(e) {
+        return !!(globalThis.WebGLRenderingContext && gl);
+    } catch (e) {
+        console.debug('WebGL support check failed:', e);
         return false;
     }
 }

--- a/style.css
+++ b/style.css
@@ -28,18 +28,32 @@ canvas {
 }
 
 #progress-bar {
+    display: block;
     width: 100%;
     height: 2px;
-    background: rgba(255, 255, 255, 0.2);
     margin-top: 10px;
+    border: none;
     border-radius: 1px;
     overflow: hidden;
+    appearance: none;
+    -webkit-appearance: none;
+    background: rgba(255, 255, 255, 0.2);
 }
 
-#progress-fill {
-    width: 0%;
-    height: 100%;
+#progress-bar::-webkit-progress-bar {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 1px;
+}
+
+#progress-bar::-webkit-progress-value {
     background: white;
+    border-radius: 1px;
+    transition: width 0.1s ease;
+}
+
+#progress-bar::-moz-progress-bar {
+    background: white;
+    border-radius: 1px;
     transition: width 0.1s ease;
 }
 
@@ -162,7 +176,7 @@ canvas {
 
 .retry-button {
     padding: 10px 24px;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #4c3fc0 0%, #5f3a8c 100%);
     color: white;
     border: none;
     border-radius: 6px;


### PR DESCRIPTION
## Summary
Fixes all 42 OPEN/CONFIRMED maintainability issues flagged by [SonarQube](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=dbelyaev_tarelka):

- **S7764** (`window` → `globalThis`, 14×) — `controls.js`, `main.js`, `utils.js`
- **S7748** (drop trailing `.0` fraction, 20×) — `config.js`
- **S6582** (optional chain) — `main.js`
- **S6660** (else-only-if → else if) — `main.js`
- **S7735** (invert negated condition) — `snow.js`
- **S7762** (`Element.remove()` over `parentNode.removeChild()`) — `snow.js`
- **S2486** (handle or drop caught exception) — `utils.js`, now logs via `console.debug`
- **S6819** (`role="status"`/`role="progressbar"` → `<output>`/`<progress>`, 2×) — `index.html`; also updated `loader.js`'s dynamically-rebuilt retry UI and `style.css` for consistency, since it renders the same markup
- **S7924** (text/background contrast) — `.retry-button` gradient darkened so white text passes WCAG AA

Sonar's reported line numbers for `main.js` and `style.css` were stale relative to `main` (later commits shifted them); actual locations were cross-checked against git history before fixing.

## Test plan
- [x] Served the site locally and loaded the model — no console errors
- [x] Verified the `<output>`/`<progress>` swap renders and updates correctly (checked `#loading` markup and progress fill visually, including the retry-attempt path in `loader.js`)
- [x] Verified the darkened retry-button gradient still renders correctly and improves contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)