### PR TITLE
fix(hosting): force revalidation on app code and stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ This site is hosted via [Cloudflare Pages](https://pages.cloudflare.com/), provi
 
 ### Caching
 
-There's no build step and no content-hashed filenames, so `_headers` forces `src/*`
-and `style.css` to revalidate on every request. Without that, Cloudflare's default
+There's no build step and no content-hashed filenames, so `_headers` forces `/src/*`
+and `/style.css` to revalidate on every request.
 `max-age=14400` lets a browser or edge PoP keep serving one file's pre-deploy copy
 for up to 4 hours after a related file has already updated — e.g. an old cached
 `renderer.js` paired with a freshly deployed `style.css` once caused PS1 mode to

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ fails if they drift, so bump both together (and refresh the SRI hashes in the im
 
 This site is hosted via [Cloudflare Pages](https://pages.cloudflare.com/), providing fast global delivery through Cloudflare's edge network.
 
+### Caching
+
+There's no build step and no content-hashed filenames, so `_headers` forces `src/*`
+and `style.css` to revalidate on every request. Without that, Cloudflare's default
+`max-age=14400` lets a browser or edge PoP keep serving one file's pre-deploy copy
+for up to 4 hours after a related file has already updated — e.g. an old cached
+`renderer.js` paired with a freshly deployed `style.css` once caused PS1 mode to
+render into a shrunken viewport. `index.html` doesn't need the same treatment;
+Cloudflare Pages already serves it `max-age=0, must-revalidate` by default.
+
 ### Content Security Policy
 
 The page ships a strict CSP with no `'unsafe-inline'`; the single inline script (the

--- a/_headers
+++ b/_headers
@@ -7,7 +7,7 @@
 # render into a shrunken viewport: an old cached src/renderer.js (which relied
 # on a `.renderer--ps1` CSS rule to stretch the low-res buffer) paired with a
 # freshly deployed style.css (that rule was removed once renderer.js started
-# setting the display size inline). Force revalidation on every load instead so
+# setting the display size inline). Force revalidation on every load instead, so
 # app code and styles can never drift apart after a deploy.
 /src/*
   Cache-Control: no-cache

--- a/_headers
+++ b/_headers
@@ -1,0 +1,16 @@
+# Cloudflare Pages custom headers: https://developers.cloudflare.com/pages/configuration/headers/
+#
+# App code and stylesheet ship unversioned filenames (no build step, no content
+# hashing), so Cloudflare's default `max-age=14400` lets a browser or edge PoP
+# keep serving a pre-deploy copy of one file for up to 4 hours after another,
+# related file has already updated. That skew previously caused PS1 mode to
+# render into a shrunken viewport: an old cached src/renderer.js (which relied
+# on a `.renderer--ps1` CSS rule to stretch the low-res buffer) paired with a
+# freshly deployed style.css (that rule was removed once renderer.js started
+# setting the display size inline). Force revalidation on every load instead so
+# app code and styles can never drift apart after a deploy.
+/src/*
+  Cache-Control: no-cache
+
+/style.css
+  Cache-Control: no-cache


### PR DESCRIPTION
## Summary

- Diagnosed the reported PS1-mode "smaller viewport" bug: it's not a code defect in the current `renderer.js` — that logic is correct and self-consistent. Verified with `curl` (uncached, always got the fixed JS) vs. a real browser tab that had visited the site earlier this session and served a stale, pre-fix `renderer.js` for the same URL.
- Root cause: Cloudflare Pages serves `src/*` and `style.css` unversioned with `Cache-Control: public, max-age=14400`. The deploy in #18 changed `renderer.js` and `style.css` together (moved canvas sizing inline, removed the `.renderer--ps1 { width: 100vw; height: 100vh }` CSS rule it used to depend on). A browser/edge PoP holding a pre-deploy `renderer.js` (which still relies on that CSS rule to stretch the low-res PS1 canvas) paired with the already-updated `style.css` (rule gone) renders the canvas at its native half-size buffer instead of full viewport — exactly the reported symptom. Toggling PS1 off self-heals because the old code's non-PS1 branch passes `updateStyle=true` by default.
- Add `_headers` (Cloudflare Pages convention) forcing `src/*` and `style.css` to revalidate on every request, so app code and stylesheet can never drift apart after a future deploy. `index.html` is untouched — Cloudflare already serves it `max-age=0, must-revalidate`.
- Documented the caching model in a new README "Caching" section.

## Test plan

- [x] `npm test` — 35/35 passing, unaffected (no application logic changed)
- [x] Reproduced the stale-cache mismatch live against `tarelka.xyz` and confirmed it matches the reported symptom
- [ ] After deploy, confirm `curl -sI https://tarelka.xyz/src/renderer.js` and `.../style.css` report the new `Cache-Control: no-cache` header
- [ ] Note: browsers/edges that already cached the old 4h-TTL files will still serve them until that TTL naturally expires; this fix prevents recurrence on future deploys, it doesn't retroactively clear existing caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)