### PR TITLE
fix(snow): pixelate snow effect in PS1 mode

### DIFF
--- a/src/snow.js
+++ b/src/snow.js
@@ -82,7 +82,14 @@ export class SnowEffect {
         // Style canvas
         this.canvas.className = 'snow-canvas';
         this.canvas.setAttribute('aria-hidden', 'true');
-        
+
+        // PS1 mode: draw at a fraction of viewport resolution and let the CSS
+        // upscale with nearest-neighbor filtering, matching the WebGL renderer's
+        // pixelation (see renderer.js computeRenderSize).
+        if (CONFIG.ps1Style) {
+            this.canvas.classList.add('snow-canvas--ps1');
+        }
+
         document.querySelector('main').appendChild(this.canvas);
         
         this.resize();
@@ -93,9 +100,12 @@ export class SnowEffect {
     }
     
     resize() {
-        this.canvas.width = window.innerWidth;
-        this.canvas.height = window.innerHeight;
-        
+        const scale = CONFIG.ps1Style ? 1 / CONFIG.ps1PixelScale : 1;
+        this.canvas.width = Math.max(1, Math.floor(window.innerWidth * scale));
+        this.canvas.height = Math.max(1, Math.floor(window.innerHeight * scale));
+        this.canvas.style.width = `${window.innerWidth}px`;
+        this.canvas.style.height = `${window.innerHeight}px`;
+
         const w = this.canvas.width;
         const h = this.canvas.height;
         

--- a/style.css
+++ b/style.css
@@ -239,6 +239,12 @@ canvas {
     z-index: 1000;
 }
 
+/* Display size is set inline by SnowEffect.resize(); only the upscaling
+   filter is styled here, so the low-res buffer stays crisp instead of blurred. */
+.snow-canvas--ps1 {
+    image-rendering: pixelated;
+}
+
 .sr-only {
     position: absolute;
     width: 1px;


### PR DESCRIPTION
## Summary
- Snow renders on its own `<canvas>` (`SnowEffect` in `src/snow.js`), separate from the three.js scene canvas. PS1 mode's pixelation (low-res drawing buffer + `image-rendering: pixelated`) was only wired up in `renderer.js`/`computeRenderSize`, so snowflakes stayed smooth anti-aliased circles even when PS1 style was active.
- `resize()` now shrinks the snow canvas's internal buffer by `1 / CONFIG.ps1PixelScale` when `CONFIG.ps1Style` is on (CSS size stays full-viewport for upscaling), matching the renderer's approach.
- Added a `snow-canvas--ps1` class + `image-rendering: pixelated` CSS rule, mirroring `.renderer--ps1`.

## Test plan
- [x] `npx vitest run` — 35/35 tests pass
- [x] Reviewed `resize()` / draw path manually against `renderer.js`'s `computeRenderSize` for parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)